### PR TITLE
Modified to recognize floating slave devices on bootstrap.

### DIFF
--- a/inputplug.c
+++ b/inputplug.c
@@ -449,6 +449,7 @@ int main(int argc, char *argv[])
                 break;
             case XCB_INPUT_DEVICE_TYPE_SLAVE_POINTER:
             case XCB_INPUT_DEVICE_TYPE_SLAVE_KEYBOARD:
+            case XCB_INPUT_DEVICE_TYPE_FLOATING_SLAVE:
                 handle_device(info->deviceid, info->type, XISlaveAdded, name);
                 handle_device(info->deviceid, info->type, XIDeviceEnabled, name);
                 break;


### PR DESCRIPTION
I noticed that floating slave devices were not generating calls on bootstrap (with the `-0` argument).  I happen to need them to, so this will allow them to be recognized.