### PR TITLE
Do not chdir to / in daemon mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn format_device_type(device_type: DeviceType) -> String {
 }
 
 impl<T> HierarchyChangeEvent<T> for XIDeviceInfo {
-    fn to_cmdline(&self, conn: &impl RequestConnection) -> Vec<String> {
+    fn to_cmdline(&self, _conn: &impl RequestConnection) -> Vec<String> {
         vec![
             self.deviceid.to_string(),
             format_device_type(self.type_),

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,11 @@ fn main() -> Result<()> {
     };
 
     if !opt.foreground {
-        daemon(false, opt.verbose).context("Cannot daemonize")?;
+        daemon(
+            true, // nochdir: retain current directory
+            opt.verbose,
+        )
+        .context("Cannot daemonize")?;
 
         println!("Daemonized.");
 


### PR DESCRIPTION
# Why

`inputplug` was behaving differently and in a confusing way when run in foreground (-n) vs daemon mode:
* in foreground mode, command would be executed from the current directory
* in daemon mode, command would be executed from /
so a command with a relative path would work in foreground mode, but (silently) fail in daemon mode.

# How

Pass `false` as `nochdir` parameter to `daemon` call in order to _not_ chdir to /.